### PR TITLE
Fixed Bug deleting Ratings

### DIFF
--- a/src/main/java/com/example/essensgetter_2_0/JPA/entities/meals/Meal.java
+++ b/src/main/java/com/example/essensgetter_2_0/JPA/entities/meals/Meal.java
@@ -24,9 +24,13 @@ public abstract class Meal {
     private String category;
     private LocalDate servingDate;
 
+    @EqualsAndHashCode.Exclude
     private Integer responseCode;
+    @EqualsAndHashCode.Exclude
     private Double rating = 0.0;
+    @EqualsAndHashCode.Exclude
     private Integer votes = 0;
+    @EqualsAndHashCode.Exclude
     private Integer starsTotal = 0;
 
     public Meal() {


### PR DESCRIPTION
While comparing the meals from OpenMensa with the meals from the database the result was false if the meal got a rating. I annotated the attributes in Meal.java with EqualsAndHashcode.Exclude so the attributes are not compared. ------------Fixed-------------